### PR TITLE
Fix Lumina Sounds copy and enforce light theme

### DIFF
--- a/music/index.html
+++ b/music/index.html
@@ -99,12 +99,12 @@
 
             <div class="ls-hero-concept">
                 <p class="concept-jp ls-serif">
-                    デジタルとフィジカルの境界が曖昧になった今、私たちは音の肌触りを追求します。<br>
-                    人間らしい響き、繋がる質感。Lumina Soundsは、静寂を設計し、雑音を紡ぎ、<br>
-                    すべての振動を通じて表現の自由を守り続けます。
+                    Lumina Soundsは、高品質なオーディオ体験とプライバシーの融合を追求するブランドです。<br>
+                    クリアな音質と洗練されたデザインで、日常のサウンドスケープを豊かにし、<br>
+                    すべてのユーザーに安心と快適な音楽環境を提供します。
                 </p>
                 <p class="concept-en">
-                    In an era where the digital and physical blur, we pursue the texture of sound—the raw, human resonance that connects us. Lumina Sounds: Engineering silence, crafting noise, preserving the freedom of expression through every vibration.
+                    Lumina Sounds is a brand that pursues the fusion of high-quality audio experiences and privacy. With clear sound quality and sophisticated design, we enrich your daily soundscape and provide a secure, comfortable musical environment for all users.
                 </p>
             </div>
 
@@ -123,14 +123,14 @@
                 <!-- Product 1 -->
                 <article class="ls-card">
                     <div class="ls-card-meta">
-                        <span class="ls-meta">EQUIPMENT</span>
+                        <span class="ls-meta">HEADPHONES</span>
                         <span class="ls-meta">LMN-001</span>
                     </div>
                     <div class="ls-card-image">
                         <div class="image-placeholder">LMN-01</div>
                     </div>
                     <div class="ls-card-content">
-                        <h3 class="ls-serif">Transcendent Studio Headphones</h3>
+                        <h3 class="ls-serif">Studio Headphones</h3>
                         <p class="ls-price">¥38,500 <span class="ls-meta">TAX INCL.</span></p>
                         <a href="#" class="ls-btn btn-buy">Purchase</a>
                     </div>
@@ -139,14 +139,14 @@
                 <!-- Product 2 -->
                 <article class="ls-card">
                     <div class="ls-card-meta">
-                        <span class="ls-meta">ANALOG</span>
+                        <span class="ls-meta">VINYL</span>
                         <span class="ls-meta">LMN-002</span>
                     </div>
                     <div class="ls-card-image">
                         <div class="image-placeholder">LMN-02</div>
                     </div>
                     <div class="ls-card-content">
-                        <h3 class="ls-serif">Digital Silence Vinyl</h3>
+                        <h3 class="ls-serif">Original Vinyl</h3>
                         <p class="ls-price">¥4,950 <span class="ls-meta">TAX INCL.</span></p>
                         <a href="#" class="ls-btn btn-buy">Purchase</a>
                     </div>
@@ -155,14 +155,14 @@
                 <!-- Product 3 -->
                 <article class="ls-card">
                     <div class="ls-card-meta">
-                        <span class="ls-meta">MEDIA</span>
+                        <span class="ls-meta">CASSETTE</span>
                         <span class="ls-meta">LMN-003</span>
                     </div>
                     <div class="ls-card-image">
                         <div class="image-placeholder">LMN-03</div>
                     </div>
                     <div class="ls-card-content">
-                        <h3 class="ls-serif">Lumina Archive Cassette</h3>
+                        <h3 class="ls-serif">Original Cassette</h3>
                         <p class="ls-price">¥2,200 <span class="ls-meta">TAX INCL.</span></p>
                         <a href="#" class="ls-btn btn-buy">Purchase</a>
                     </div>
@@ -181,16 +181,16 @@
 
         <section id="contact" class="ls-section ls-contact" data-ls-reveal>
             <div class="ls-section-header">
-                <div class="ls-meta">PROTOCOL / INQUIRY</div>
+                <div class="ls-meta">INQUIRY</div>
                 <h2 class="ls-serif section-title">CONTACT</h2>
             </div>
             <div class="ls-contact-content">
                 <p class="concept-jp ls-serif">
-                    製品に関するお問い合わせ、コラボレーションのご提案はこちらから。<br>
-                    新しい響きを共に創り出すパートナーを常に探しています。
+                    製品に関するお問い合わせ、コラボレーションのご提案は<br>
+                    こちらから受け付けております。
                 </p>
                 <div class="ls-contact-actions">
-                    <a href="mailto:me@lumina-group.jp" class="ls-btn">Send Transmission</a>
+                    <a href="mailto:me@lumina-group.jp" class="ls-btn">Contact Us</a>
                 </div>
             </div>
         </section>
@@ -200,7 +200,7 @@
         <div class="container">
             <div class="ls-footer-grid">
                 <div class="ls-footer-brand">
-                    <div class="ls-meta">SYSTEM-77 / LUMINA SOUNDS</div>
+                    <div class="ls-meta">LUMINA SOUNDS</div>
                     <h3 class="ls-serif">LUMINA</h3>
                 </div>
                 <div class="ls-footer-links">
@@ -221,7 +221,7 @@
             </div>
             <div class="ls-footer-bottom">
                 <div class="ls-meta">© 2025 LUMINA GROUP. ALL RIGHTS RESERVED.</div>
-                <div class="ls-meta">ENCRYPTED RESISTANCE / SOUND ARCHIVE</div>
+                <div class="ls-meta">SOUND ARCHIVE</div>
             </div>
         </div>
     </footer>

--- a/resource/css/utilities/accessibility.css
+++ b/resource/css/utilities/accessibility.css
@@ -42,30 +42,6 @@ a:focus {
     }
 }
 
-/* Dark Mode Support */
-@media (prefers-color-scheme: dark) {
-    :root {
-        --bg-color: #0a0a0a;
-        --secondary-bg: #1a1a1a;
-        --text-color: #ffffff;
-        --text-secondary: #a1a1aa;
-        --border-color: #27272a;
-    }
-
-    .navbar {
-        background-color: rgba(10, 10, 10, 0.8);
-    }
-
-    .navbar.scrolled {
-        background-color: rgba(10, 10, 10, 0.95);
-    }
-
-    .mission-card,
-    .project-card {
-        background: var(--secondary-bg);
-    }
-}
-
 /* Print Styles */
 @media print {
     .navbar,


### PR DESCRIPTION
This PR removes the dark mode media query so the website stays in light mode consistently, and it refactors the Lumina Sounds copy to be more professional and less dramatic (e.g. less "chuunibyou"), as requested.

---
*PR created automatically by Jules for task [5705665271862952433](https://jules.google.com/task/5705665271862952433) started by @meowkawaiijp*