### PR TITLE
Lumina SoundsのVinci公開ページを準備

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+* @meowkawaiijp
+
+/music/ @meowkawaiijp
+/.github/ @meowkawaiijp

--- a/.github/workflows/storefront.yml
+++ b/.github/workflows/storefront.yml
@@ -1,0 +1,19 @@
+name: storefront
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: python -m unittest discover -s tests -p 'test*.py'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 _lumina_news_updater/
 output/playwright/
 .playwright-cli/
+__pycache__/
+*.py[cod]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do not disclose suspected vulnerabilities in a public issue.
+
+Use GitHub's private vulnerability reporting feature for this repository. Include the affected URL or file, reproduction steps, and the impact you observed. We will acknowledge a complete report as soon as practical and coordinate disclosure after a fix is available.
+
+Do not include customer data, credentials, private keys, access tokens, or other secrets in a report. If a secret may have been exposed, state the type of secret without copying its value.
+
+## Supported surface
+
+Only the version currently published from the default branch is supported. Preview branches and disabled storefront links are not production services.

--- a/music/index.html
+++ b/music/index.html
@@ -4,9 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Lumina Sound - 個人音楽ブランド / Multi Effects Prototype</title>
+    <title>Lumina Sounds - 個人音楽ブランド</title>
     <meta name="description"
-        content="Lumina Sound は、個人のアーティスト活動と自作マルチエフェクター開発をつなぐ音楽ブランドです。音、回路、ソフトウェア、演奏体験を一体で探求しています。">
+        content="Lumina Soundsは、個人事業Luminaが運営する音楽ブランドです。">
     <meta name="keywords" content="Lumina Sound, Lumina Sounds, 音楽, アーティスト, マルチエフェクター, エフェクター, 自作機材">
 
     <!-- Canonical URL -->
@@ -14,17 +14,17 @@
 
     <!-- Social Meta Tags -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="Lumina Sound - 個人音楽ブランド / Multi Effects Prototype">
-    <meta property="og:description" content="個人のアーティスト活動と自作マルチエフェクター開発をつなぐ、Lumina の音楽ブランド。">
+    <meta property="og:title" content="Lumina Sounds - 個人音楽ブランド">
+    <meta property="og:description" content="個人事業Luminaが運営する音楽ブランド。">
     <meta property="og:url" content="https://lumina-group.jp/music/">
     <meta property="og:image" content="https://lumina-group.jp/resource/images/favicon/lumina-logo.png">
-    <meta property="og:site_name" content="Lumina Sound">
+    <meta property="og:site_name" content="Lumina Sounds">
     <meta property="og:locale" content="ja_JP">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Lumina Sound - 個人音楽ブランド / Multi Effects Prototype">
-    <meta name="twitter:description" content="個人のアーティスト活動と自作マルチエフェクター開発をつなぐ、Lumina の音楽ブランド。">
+    <meta name="twitter:title" content="Lumina Sounds - 個人音楽ブランド">
+    <meta name="twitter:description" content="個人事業Luminaが運営する音楽ブランド。">
     <meta name="twitter:image" content="https://lumina-group.jp/resource/images/favicon/lumina-logo.png">
 
     <link rel="stylesheet" href="/resource/css/main.css">
@@ -47,8 +47,8 @@
     {
         "@context": "https://schema.org",
         "@type": "WebPage",
-        "name": "Lumina Sound - 個人音楽ブランド / Multi Effects Prototype",
-        "description": "Lumina Sound は、個人のアーティスト活動と自作マルチエフェクター開発をつなぐ音楽ブランドです。",
+        "name": "Lumina Sounds - 個人音楽ブランド",
+        "description": "Lumina Soundsは、個人事業Luminaが運営する音楽ブランドです。",
         "url": "https://lumina-group.jp/music/",
         "isPartOf": {
             "@type": "WebSite",
@@ -72,7 +72,7 @@
 <body class="sounds-page">
     <nav class="navbar ls-navbar">
         <div class="container">
-            <a href="/music/" class="navbar-brand ls-serif">LUMINA SOUND</a>
+            <a href="/music/" class="navbar-brand ls-serif">LUMINA SOUNDS</a>
             <div class="ls-meta nav-label">ARTIST / TOKYO</div>
             <button class="navbar-toggler" aria-label="Toggle navigation" aria-expanded="false">
                 <i class="fa-solid fa-bars"></i>
@@ -91,22 +91,22 @@
         <header class="ls-hero" data-ls-reveal>
             <div class="ls-hero-labels">
                 <span class="ls-meta">ARTIST / SOUND DESIGN</span>
-                <span class="ls-meta">PROTOTYPE-000</span>
+                <span class="ls-meta">PROJECT / VINCI</span>
             </div>
 
             <h1 class="ls-hero-title ls-serif">
                 <span class="title-main">LUMINA</span>
-                <span class="title-sub">SOUND</span>
+                <span class="title-sub">SOUNDS</span>
             </h1>
 
             <div class="ls-hero-concept">
                 <p class="concept-jp ls-serif">
-                    Lumina Sound は、私個人のアーティスト活動から生まれた音楽ブランドです。<br>
-                    楽曲制作、演奏、音作り、そして自作マルチエフェクターの開発をひとつの表現として扱います。<br>
-                    完成された製品カタログではなく、音が形になっていく過程そのものを公開していきます。
+                    Lumina Soundsは、私の個人事業「Lumina」が運営する音楽ブランドです。<br>
+                    楽曲制作、演奏、音作りをひとつの表現として扱います。<br>
+                    新しいプロジェクト「Vinci」の詳細は、準備が整い次第お知らせします。
                 </p>
                 <p class="concept-en">
-                    Lumina Sound is a personal artist brand exploring music, performance, and a handmade multi-effects prototype as one continuous creative practice.
+                    Lumina Sounds is the personal music brand of Lumina. Details of Vinci will be announced when ready.
                 </p>
             </div>
 
@@ -125,60 +125,60 @@
                 <!-- Work 1 -->
                 <article class="ls-card">
                     <div class="ls-card-meta">
-                        <span class="ls-meta">EFFECTOR</span>
-                        <span class="ls-meta">LMS-FX01</span>
+                        <span class="ls-meta">PROJECT</span>
+                        <span class="ls-meta">VINCI</span>
                     </div>
                     <div class="ls-card-image">
-                        <div class="image-placeholder">FX-01</div>
+                        <div class="image-placeholder">VINCI</div>
                     </div>
                     <div class="ls-card-content">
-                        <h3 class="ls-serif">Multi Effects Prototype</h3>
-                        <p class="ls-card-copy">開発中の自作マルチエフェクター。演奏中に音色を直感的に切り替えられる操作感と、個人制作らしい音の癖を両立させます。</p>
-                        <p class="ls-price">IN DEVELOPMENT <span class="ls-meta">NOT FOR SALE</span></p>
-                        <a href="#contact" class="ls-btn btn-buy">Ask Details</a>
+                        <h3 class="ls-serif">Vinci</h3>
+                        <p class="ls-card-copy">詳細は準備が整い次第お知らせします。</p>
+                        <p class="ls-price">COMING SOON</p>
+                        <a href="#contact" class="ls-btn btn-buy">Follow Updates</a>
                     </div>
                 </article>
 
                 <!-- Work 2 -->
                 <article class="ls-card">
                     <div class="ls-card-meta">
-                        <span class="ls-meta">MUSIC</span>
-                        <span class="ls-meta">LMS-TRACKS</span>
+                        <span class="ls-meta">DIGITAL CONTENT</span>
+                        <span class="ls-meta">VINCI ADD-ONS</span>
                     </div>
                     <div class="ls-card-image">
-                        <div class="image-placeholder">AUDIO</div>
+                        <div class="image-placeholder">SOUNDS</div>
                     </div>
                     <div class="ls-card-content">
-                        <h3 class="ls-serif">Artist Works</h3>
-                        <p class="ls-card-copy">Lumina Sound の楽曲、デモ、サウンドスケッチをまとめていく場所です。完成音源だけでなく、制作途中の質感も残します。</p>
-                        <p class="ls-price">ARCHIVE <span class="ls-meta">COMING SOON</span></p>
-                        <a href="#contact" class="ls-btn btn-buy">Follow Updates</a>
+                        <h3 class="ls-serif">Official Add-ons</h3>
+                        <p class="ls-card-copy">公式追加コンテンツは個別購入です。購入権はアカウントに残り、端末利用には30日ごとのオンライン更新と7日間の猶予があります。</p>
+                        <p class="ls-price">INDIVIDUAL LICENSE <span class="ls-meta">COMING SOON</span></p>
+                        <a href="#contact" class="ls-btn btn-buy is-disabled" data-store-action="content" aria-disabled="true">販売準備中</a>
                     </div>
                 </article>
 
                 <!-- Work 3 -->
                 <article class="ls-card">
                     <div class="ls-card-meta">
-                        <span class="ls-meta">BUILD LOG</span>
-                        <span class="ls-meta">LMS-LAB</span>
+                        <span class="ls-meta">ACCOUNT</span>
+                        <span class="ls-meta">VINCI CLOUD</span>
                     </div>
                     <div class="ls-card-image">
-                        <div class="image-placeholder">LAB</div>
+                        <div class="image-placeholder">CLOUD</div>
                     </div>
                     <div class="ls-card-content">
-                        <h3 class="ls-serif">Development Notes</h3>
-                        <p class="ls-card-copy">回路、UI、プリセット、筐体、ライブでの使い勝手など、制作過程で得た知見を記録します。</p>
-                        <p class="ls-price">OPEN NOTES <span class="ls-meta">WIP</span></p>
-                        <a href="#contact" class="ls-btn btn-buy">Collaborate</a>
+                        <h3 class="ls-serif">Vinci Cloud</h3>
+                        <p class="ls-card-copy">Freeは1台・1GB、Proは最大3台・20GB。Proに無料試用期間はありません。</p>
+                        <p class="ls-price">FREE / PRO <span class="ls-meta">COMING SOON</span></p>
+                        <a href="#contact" class="ls-btn btn-buy is-disabled" data-store-action="cloud" aria-disabled="true">登録準備中</a>
                     </div>
                 </article>
             </div>
 
             <div class="ls-stripe-checkout ls-note" data-ls-reveal>
-                <div class="ls-meta checkout-label">STATUS / PROTOTYPE</div>
+                <div class="ls-meta checkout-label" data-store-status>STATUS / PREPARING</div>
                 <p class="concept-jp ls-serif">
-                    現在は販売ページではなく、制作過程と活動情報を伝えるためのページとして調整しています。<br>
-                    頒布・受注・試奏募集を始める場合は、価格、仕様、納期、保証範囲を明確にしたうえで公開します。
+                    現在は活動情報、Cloudプラン、ライセンス方針をお知らせするためのページです。<br>
+                    Vinciの製品仕様、価格、販売時期などの詳細はまだ公開していません。
                 </p>
             </div>
         </section>
@@ -190,8 +190,8 @@
             </div>
             <div class="ls-contact-content">
                 <p class="concept-jp ls-serif">
-                    音源、機材開発、試奏、コラボレーションに関するご連絡はこちらから。<br>
-                    まだ固まりきっていない段階の相談も歓迎します。
+                    音源、音楽制作、コラボレーションに関するお問い合わせはこちらから。<br>
+                    Vinciの詳細は公開発表をお待ちください。
                 </p>
                 <div class="ls-contact-actions">
                     <a href="mailto:me@lumina-group.jp" class="ls-btn">Contact</a>
@@ -204,7 +204,7 @@
         <div class="container">
             <div class="ls-footer-grid">
                 <div class="ls-footer-brand">
-                    <div class="ls-meta">LUMINA SOUND</div>
+                    <div class="ls-meta">LUMINA SOUNDS</div>
                     <h3 class="ls-serif">LUMINA</h3>
                 </div>
                 <div class="ls-footer-links">
@@ -224,7 +224,7 @@
                 </div>
             </div>
             <div class="ls-footer-bottom">
-                <div class="ls-meta">&copy; 2026 LUMINA SOUND. ALL RIGHTS RESERVED.</div>
+                <div class="ls-meta">&copy; 2026 LUMINA SOUNDS. ALL RIGHTS RESERVED.</div>
                 <div class="ls-meta">SOUND ARCHIVE</div>
             </div>
         </div>

--- a/music/interaction.js
+++ b/music/interaction.js
@@ -3,6 +3,44 @@
  */
 
 document.addEventListener('DOMContentLoaded', () => {
+    const allowedPortalOrigin = 'https://vinci.lumina-group.jp';
+    const actions = {
+        cloud: 'cloudRegistration',
+        content: 'contentCheckout'
+    };
+
+    fetch('/music/storefront-config.json', { credentials: 'omit', cache: 'no-store' })
+        .then(response => {
+            if (!response.ok) throw new Error('storefront_config_unavailable');
+            return response.json();
+        })
+        .then(config => {
+            if (config.schemaVersion !== 1 || config.portalOrigin !== allowedPortalOrigin) {
+                throw new Error('storefront_config_invalid');
+            }
+            document.querySelectorAll('[data-store-action]').forEach(element => {
+                const action = element.dataset.storeAction;
+                const feature = actions[action];
+                const route = config.routes && config.routes[action];
+                if (!feature || config.features?.[feature] !== true || typeof route !== 'string') {
+                    return;
+                }
+                const destination = new URL(route, allowedPortalOrigin);
+                if (destination.origin !== allowedPortalOrigin) return;
+                element.href = destination.href;
+                element.classList.remove('is-disabled');
+                element.removeAttribute('aria-disabled');
+                element.textContent = action === 'cloud' ? 'Vinci Cloudへ' : '商品を見る';
+            });
+            const status = document.querySelector('[data-store-status]');
+            if (status && Object.values(config.features).some(value => value === true)) {
+                status.textContent = 'STATUS / AVAILABLE SERVICES';
+            }
+        })
+        .catch(() => {
+            // Missing or malformed public config keeps every action disabled.
+        });
+
     // Scroll Reveal Animation
     const revealElements = document.querySelectorAll('[data-ls-reveal]');
 
@@ -23,6 +61,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // Magnetic Button Effect (Refined to prevent jitter)
     const magneticBtns = document.querySelectorAll('.ls-btn');
     magneticBtns.forEach(btn => {
+        btn.addEventListener('click', event => {
+            if (btn.getAttribute('aria-disabled') === 'true') event.preventDefault();
+        });
         btn.addEventListener('mousemove', (e) => {
             const rect = btn.getBoundingClientRect();
             const x = e.clientX - rect.left - rect.width / 2;

--- a/music/pages/commerce.html
+++ b/music/pages/commerce.html
@@ -4,26 +4,26 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>特定商取引法に基づく表記 - Lumina Music</title>
-    <meta name="description" content="Lumina Music(ルミナミュージック)の特定商取引法に基づく表記。販売業者情報、お支払い方法、返品・交換について等の情報を掲載しています。">
-    <meta name="keywords" content="Lumina Music, エフェクター, ブティック, 特定商取引法, 販売業者, 返品, 交換, お支払い方法">
+    <title>特定商取引法に基づく表記 - Lumina Sounds</title>
+    <meta name="description" content="Lumina Soundsの特定商取引法に基づく表記。販売業者情報、お支払い方法、返品・交換について等の情報を掲載しています。">
+    <meta name="keywords" content="Lumina Sounds, Vinci, エフェクター, 特定商取引法, 販売業者, 返品, 交換, お支払い方法">
 
     <!-- Canonical URL -->
     <link rel="canonical" href="https://lumina-group.jp/music/pages/commerce.html">
 
     <!-- Social Meta Tags -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="特定商取引法に基づく表記 - Lumina Music">
-    <meta property="og:description" content="Lumina Music(ルミナミュージック)の特定商取引法に基づく表記。販売業者情報、お支払い方法、返品・交換について等の情報を掲載しています。">
+    <meta property="og:title" content="特定商取引法に基づく表記 - Lumina Sounds">
+    <meta property="og:description" content="Lumina Soundsの特定商取引法に基づく表記。販売業者情報、お支払い方法、返品・交換について等の情報を掲載しています。">
     <meta property="og:url" content="https://lumina-group.jp/music/pages/commerce.html">
     <meta property="og:image" content="https://lumina-group.jp/resource/images/favicon/lumina-logo.png">
-    <meta property="og:site_name" content="Lumina Music">
+    <meta property="og:site_name" content="Lumina Sounds">
     <meta property="og:locale" content="ja_JP">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="特定商取引法に基づく表記 - Lumina Music">
-    <meta name="twitter:description" content="Lumina Music(ルミナミュージック)の特定商取引法に基づく表記。販売業者情報、お支払い方法、返品・交換について等の情報を掲載しています。">
+    <meta name="twitter:title" content="特定商取引法に基づく表記 - Lumina Sounds">
+    <meta name="twitter:description" content="Lumina Soundsの特定商取引法に基づく表記。販売業者情報、お支払い方法、返品・交換について等の情報を掲載しています。">
     <meta name="twitter:image" content="https://lumina-group.jp/resource/images/favicon/lumina-logo.png">
 
     <link rel="stylesheet" href="/resource/css/main.css">
@@ -63,8 +63,8 @@
     {
         "@context": "https://schema.org",
         "@type": "WebPage",
-        "name": "特定商取引法に基づく表記 - Lumina Music",
-        "description": "Lumina Music（オーダーメイド・自作ブティックエフェクター）の特定商取引法に基づく表記。販売業者情報、お支払い方法、返品・交換について等の情報を掲載しています。",
+        "name": "特定商取引法に基づく表記 - Lumina Sounds",
+        "description": "Lumina Soundsの特定商取引法に基づく表記。販売業者情報、お支払い方法、返品・交換について等の情報を掲載しています。",
         "url": "https://lumina-group.jp/music/pages/commerce.html",
         "isPartOf": {
             "@type": "WebSite",
@@ -284,7 +284,7 @@
         <footer class="site-footer">
             <div class="footer-content">
                 <div class="footer-section">
-                    <h4>Lumina Music</h4>
+                    <h4>Lumina Sounds</h4>
                     <p>オーダーメイド・自作ブティックエフェクター</p>
                 </div>
                 <div class="footer-section">

--- a/music/pages/terms.html
+++ b/music/pages/terms.html
@@ -4,26 +4,26 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>利用規約 - Lumina Music（オーダーメイド・自作ブティックエフェクター）</title>
-    <meta name="description" content="Lumina Music（オーダーメイド・自作ブティックエフェクター）の利用規約。ご注文・お支払い・納品・保証・免責事項等について定めています。ご利用前に必ずご確認ください。">
-    <meta name="keywords" content="Lumina Music, エフェクター, ブティック, 利用規約, 利用条件, 免責事項, 特定商取引法">
+    <title>利用規約 - Lumina Sounds</title>
+    <meta name="description" content="Lumina Soundsの利用規約。ご注文・お支払い・納品・保証・免責事項等について定めています。ご利用前に必ずご確認ください。">
+    <meta name="keywords" content="Lumina Sounds, Vinci, エフェクター, 利用規約, 利用条件, 免責事項, 特定商取引法">
 
     <!-- Canonical URL -->
     <link rel="canonical" href="https://lumina-group.jp/music/pages/terms.html">
 
     <!-- Social Meta Tags -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="利用規約 - Lumina Music（オーダーメイド・自作ブティックエフェクター）">
-    <meta property="og:description" content="Lumina Music（オーダーメイド・自作ブティックエフェクター）の利用規約。ご注文・お支払い・納品・保証・免責事項等について定めています。">
+    <meta property="og:title" content="利用規約 - Lumina Sounds">
+    <meta property="og:description" content="Lumina Soundsの利用規約。ご注文・お支払い・納品・保証・免責事項等について定めています。">
     <meta property="og:url" content="https://lumina-group.jp/music/pages/terms.html">
     <meta property="og:image" content="https://lumina-group.jp/resource/images/favicon/lumina-logo.png">
-    <meta property="og:site_name" content="Lumina Music">
+    <meta property="og:site_name" content="Lumina Sounds">
     <meta property="og:locale" content="ja_JP">
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="利用規約 - Lumina Music（オーダーメイド・自作ブティックエフェクター）">
-    <meta name="twitter:description" content="Lumina Music（オーダーメイド・自作ブティックエフェクター）の利用規約。ご注文・お支払い・納品・保証・免責事項等について定めています。">
+    <meta name="twitter:title" content="利用規約 - Lumina Sounds">
+    <meta name="twitter:description" content="Lumina Soundsの利用規約。ご注文・お支払い・納品・保証・免責事項等について定めています。">
     <meta name="twitter:image" content="https://lumina-group.jp/resource/images/favicon/lumina-logo.png">
 
     <link rel="stylesheet" href="/resource/css/main.css">
@@ -63,8 +63,8 @@
     {
         "@context": "https://schema.org",
         "@type": "WebPage",
-        "name": "利用規約 - Lumina Music（オーダーメイド・自作ブティックエフェクター）",
-        "description": "Lumina Music（オーダーメイド・自作ブティックエフェクター）の利用規約。",
+        "name": "利用規約 - Lumina Sounds",
+        "description": "Lumina Soundsの利用規約。",
         "url": "https://lumina-group.jp/music/pages/terms.html",
         "isPartOf": { "@type": "WebSite", "name": "Lumina", "url": "https://lumina-group.jp/" },
         "publisher": {
@@ -103,7 +103,7 @@
 
                 <div class="commerce-content">
                     <p class="commerce-intro">
-                        Lumina Music（ルミナミュージック）が提供するオーダーメイドエフェクターおよび自作ブティックエフェクターの製作・販売・関連サービス（以下「本サービス」）の利用条件を定めます。<br>
+                        Lumina Soundsが提供するVinci、音楽機材、デジタルコンテンツおよび関連サービス（以下「本サービス」）の利用条件を定めます。<br>
                         ご注文・お問い合わせ・ご利用の前に、本規約を必ずお読みください。本サービスを利用した時点で、本規約に同意したものとみなします。
                     </p>
 
@@ -301,7 +301,7 @@
         <footer class="site-footer">
             <div class="footer-content">
                 <div class="footer-section">
-                    <h4>Lumina Music</h4>
+                    <h4>Lumina Sounds</h4>
                     <p>オーダーメイド・自作ブティックエフェクター</p>
                 </div>
                 <div class="footer-section">

--- a/music/redesign.css
+++ b/music/redesign.css
@@ -144,6 +144,18 @@
     outline-offset: 4px;
 }
 
+.ls-btn.is-disabled,
+.ls-btn[aria-disabled="true"] {
+    cursor: not-allowed;
+    opacity: 0.48;
+}
+
+.ls-btn.is-disabled:hover,
+.ls-btn[aria-disabled="true"]:hover {
+    background: transparent;
+    color: var(--ls-text);
+}
+
 .ls-btn::before {
     content: "[+] ";
     margin-right: 0.5rem;

--- a/music/storefront-config.json
+++ b/music/storefront-config.json
@@ -1,0 +1,12 @@
+{
+  "schemaVersion": 1,
+  "portalOrigin": "https://vinci.lumina-group.jp",
+  "features": {
+    "cloudRegistration": false,
+    "contentCheckout": false
+  },
+  "routes": {
+    "cloud": "/sign-in",
+    "content": "/store/content"
+  }
+}

--- a/tests/test_storefront.py
+++ b/tests/test_storefront.py
@@ -1,0 +1,76 @@
+import json
+import unittest
+from html.parser import HTMLParser
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class CardCopyParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.card_copy = []
+        self._capture = False
+        self._text = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag != "p":
+            return
+        classes = dict(attrs).get("class", "").split()
+        if "ls-card-copy" in classes:
+            self._capture = True
+            self._text = []
+
+    def handle_data(self, data):
+        if self._capture:
+            self._text.append(data)
+
+    def handle_endtag(self, tag):
+        if tag == "p" and self._capture:
+            self.card_copy.append("".join(self._text).strip())
+            self._capture = False
+            self._text = []
+
+
+class StorefrontContractTest(unittest.TestCase):
+    def setUp(self):
+        self.config = json.loads(
+            (ROOT / "music/storefront-config.json").read_text(encoding="utf-8")
+        )
+        self.index = (ROOT / "music/index.html").read_text(encoding="utf-8")
+        self.script = (ROOT / "music/interaction.js").read_text(encoding="utf-8")
+
+    def test_public_storefront_is_fail_closed(self):
+        self.assertEqual(self.config["schemaVersion"], 1)
+        self.assertEqual(self.config["portalOrigin"], "https://vinci.lumina-group.jp")
+        self.assertTrue(self.config["features"])
+        self.assertTrue(all(value is False for value in self.config["features"].values()))
+        self.assertEqual(self.index.count('aria-disabled="true"'), 2)
+
+    def test_routes_are_relative_and_cannot_redirect_to_another_origin(self):
+        for route in self.config["routes"].values():
+            self.assertTrue(route.startswith("/"))
+            self.assertFalse(route.startswith("//"))
+        self.assertIn("destination.origin !== allowedPortalOrigin", self.script)
+
+    def test_storefront_discloses_offline_renewal_and_closed_checkout(self):
+        self.assertIn("30日ごとのオンライン更新と7日間の猶予", self.index)
+        self.assertIn("Freeは1台・1GB、Proは最大3台・20GB", self.index)
+        self.assertIn("製品仕様、価格、販売時期などの詳細はまだ公開していません", self.index)
+
+    def test_product_cards_contain_only_approved_public_copy(self):
+        parser = CardCopyParser()
+        parser.feed(self.index)
+        self.assertEqual(
+            parser.card_copy,
+            [
+                "詳細は準備が整い次第お知らせします。",
+                "公式追加コンテンツは個別購入です。購入権はアカウントに残り、端末利用には30日ごとのオンライン更新と7日間の猶予があります。",
+                "Freeは1台・1GB、Proは最大3台・20GB。Proに無料試用期間はありません。",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

- 音楽ブランド表記をLumina Soundsへ統一
- Vinciは名称と準備中表示に限定
- 公開可能なCloudプランと追加コンテンツのライセンス条件を掲載
- Cloud登録・コンテンツ販売の導線を設定ファイル既定OFFでfail-closed化
- 公開文言の契約テストとSecurity Policy/CODEOWNERSを追加

## 検証

- `python3 -m unittest discover -s tests -p 'test*.py'`
- 公開範囲のローカル監査
- `git diff --check`

販売・登録導線はこのPR時点では有効化しません。