### PR TITLE
Vinciの公開前情報を名称に限定

### DIFF
--- a/music/index.html
+++ b/music/index.html
@@ -7,7 +7,7 @@
     <title>Lumina Sounds - 個人音楽ブランド</title>
     <meta name="description"
         content="Lumina Soundsは、個人事業Luminaが運営する音楽ブランドです。">
-    <meta name="keywords" content="Lumina Sound, Lumina Sounds, 音楽, アーティスト, マルチエフェクター, エフェクター, 自作機材">
+    <meta name="keywords" content="Lumina, Lumina Sounds, 音楽, アーティスト, Vinci">
 
     <!-- Canonical URL -->
     <link rel="canonical" href="https://lumina-group.jp/music/">

--- a/music/pages/commerce.html
+++ b/music/pages/commerce.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>特定商取引法に基づく表記 - Lumina Sounds</title>
     <meta name="description" content="Lumina Soundsの特定商取引法に基づく表記。販売業者情報、お支払い方法、返品・交換について等の情報を掲載しています。">
-    <meta name="keywords" content="Lumina Sounds, Vinci, エフェクター, 特定商取引法, 販売業者, 返品, 交換, お支払い方法">
+    <meta name="keywords" content="Lumina Sounds, 特定商取引法, 販売業者, 返品, 交換, お支払い方法">
 
     <!-- Canonical URL -->
     <link rel="canonical" href="https://lumina-group.jp/music/pages/commerce.html">

--- a/music/pages/terms.html
+++ b/music/pages/terms.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>利用規約 - Lumina Sounds</title>
     <meta name="description" content="Lumina Soundsの利用規約。ご注文・お支払い・納品・保証・免責事項等について定めています。ご利用前に必ずご確認ください。">
-    <meta name="keywords" content="Lumina Sounds, Vinci, エフェクター, 利用規約, 利用条件, 免責事項, 特定商取引法">
+    <meta name="keywords" content="Lumina Sounds, 利用規約, 利用条件, 免責事項, 特定商取引法">
 
     <!-- Canonical URL -->
     <link rel="canonical" href="https://lumina-group.jp/music/pages/terms.html">
@@ -103,7 +103,7 @@
 
                 <div class="commerce-content">
                     <p class="commerce-intro">
-                        Lumina Soundsが提供するVinci、音楽機材、デジタルコンテンツおよび関連サービス（以下「本サービス」）の利用条件を定めます。<br>
+                        Lumina Soundsが提供する商品・サービス（以下「本サービス」）の利用条件を定めます。<br>
                         ご注文・お問い合わせ・ご利用の前に、本規約を必ずお読みください。本サービスを利用した時点で、本規約に同意したものとみなします。
                     </p>
 


### PR DESCRIPTION
## 概要

- 公開ページの検索メタデータから未発表の製品カテゴリ表現を除去
- 法定表示・利用規約のVinci固有カテゴリ表現を一般的な商品・サービス表現へ変更
- 公開可能なCloudプランとライセンス条件は維持

## 検証

- `python3 -m unittest discover -s tests -p 'test*.py'`
- private disclosure boundary scan
- `git diff --check`

販売・登録導線は引き続き既定OFFです。