### PR TITLE
公開CIのActionを固定SHAへ更新

### DIFF
--- a/.github/workflows/storefront.yml
+++ b/.github/workflows/storefront.yml
@@ -11,9 +11,9 @@ permissions:
 jobs:
   contract:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
-          python-version: "3.12"
-      - run: python -m unittest discover -s tests -p 'test*.py'
+          persist-credentials: false
+      - run: python3 -m unittest discover -s tests -p 'test*.py'


### PR DESCRIPTION
## 概要

- storefront CIのcheckout Actionを固定commit SHAへ変更
- checkout credentialを保持しない設定へ変更
- runner標準のPython 3を使い、可変tagのsetup Action依存を削除
- job timeoutを5分へ制限

## 検証

- `python3 -m unittest discover -s tests -p 'test*.py'`
- `git diff --check`